### PR TITLE
Json ld files for http-problem-rdf

### DIFF
--- a/http-problem-rdf/README.md
+++ b/http-problem-rdf/README.md
@@ -1,0 +1,3 @@
+# RDF vocabulary and JSON-LD mapping for HTTP Problem Reports
+
+This RDF based representation and JSON-LD mapping is based on the JSON model defined by [draft-ietf-appsawg-http-problem: "Problem Details for HTTP APIs"](http://www.ietf.org/internet-drafts/draft-ietf-appsawg-http-problem-01.txt)

--- a/http-problem-rdf/http-problem-context.jsonld
+++ b/http-problem-rdf/http-problem-context.jsonld
@@ -1,0 +1,13 @@
+{
+  "@context": {
+    "problem": "https://tools.ietf.org/html/rfcXXXX/vocab#",
+    "instance": "@id",
+    "title": "problem:title",
+    "status": "problem:status",
+    "detail": "problem:detail",
+    "type": {
+      "@id": "problem:type",
+      "@type": "@id"
+    }
+  }
+}

--- a/http-problem-rdf/http-problem-vocab.jsonld
+++ b/http-problem-rdf/http-problem-vocab.jsonld
@@ -7,6 +7,15 @@
     "owl": "http://www.w3.org/2002/07/owl#",
     "defines": {
       "@reverse": "rdfs:isDefinedBy"
+    },
+    "rdfs:domain": {
+      "@type": "@id"
+    },
+    "rdfs:range": {
+      "@type": "@id"
+    },
+    "rdfs:subClassOf": {
+      "@type": "@id"
     }
   },
   "@id": "https://tools.ietf.org/html/rfcXXXX/vocab",

--- a/http-problem-rdf/http-problem-vocab.jsonld
+++ b/http-problem-rdf/http-problem-vocab.jsonld
@@ -1,0 +1,61 @@
+{
+  "@context": {
+    "problem": "https://tools.ietf.org/html/rfcXXXX/vocab#",
+    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
+    "owl": "http://www.w3.org/2002/07/owl#",
+    "defines": {
+      "@reverse": "rdfs:isDefinedBy"
+    }
+  },
+  "@id": "https://tools.ietf.org/html/rfcXXXX/vocab",
+  "@type": "owl:Ontology",
+  "comment": "This document defines a 'problem detail' vocabulary as a way to carry machine-readable details of errors in a HTTP response, to avoid the need to invent new error response formats for HTTP APIs.",
+  "rdfs:label": "Problem Details for HTTP APIs",
+  "defines": [
+    {
+      "@id": "problem:HttpProblem",
+      "@type": "rdfs:Class",
+      "rdfs:comment": "The class of http problem detail descriptions",
+      "rdfs:subClassOf": [
+        "rdfs:Resource"
+      ]
+    },
+    {
+      "@id": "problem:instance",
+      "@type": "xsd:string",
+      "rdfs:comment": "A URI reference that identifies the specific occurrence of the problem",
+      "rdfs:domain": "problem:HttpProblem",
+      "rdfs:range": "xsd:string"
+    },
+    {
+      "@id": "problem:title",
+      "@type": "rdf:Property",
+      "rdfs:comment": "A short, human-readable summary of the problem type",
+      "rdfs:domain": "problem:HttpProblem",
+      "rdfs:range": "xsd:string"
+    },
+    {
+      "@id": "problem:status",
+      "@type": "rdf:Property",
+      "rdfs:comment": "The HTTP status code ([RFC7231], Section 6)",
+      "rdfs:domain": "problem:HttpProblem",
+      "rdfs:range": "xsd:integer"
+    },
+    {
+      "@id": "problem:detail",
+      "@type": "rdf:Property",
+      "rdfs:comment": "A human readable explanation specific to this occurence of the problem",
+      "rdfs:domain": "problem:HttpProblem",
+      "rdfs:range": "xsd:string"
+    },
+    {
+      "@id": "problem:type",
+      "@type": "xsd:string",
+      "rdfs:comment": "A URI reference [RFC3986] that identifies the problem type. When this member is not present, its value is assumed to be 'about:blank'",
+      "rdfs:domain": "problem:HttpProblem",
+      "rdfs:range": "xsd:string"
+    }
+  ]
+}


### PR DESCRIPTION
Added json-ld files: vocab and context. Both can be merged, but for now I find it clearer to keep them separate so the function of each file is more obvious. The vocab defines the terms as an Ontology. The json-ld context maps the ontology terms to json attributes.

I have also switched to an HTTP URI as identifier. Linked data really asks for dereferenceable URIs [1]: 

> Use URIs as names for things
> Use HTTP URIs so that people can look up those names.
> When someone looks up a URI, provide useful information, using the standards (RDF*, SPARQL)
> Include links to other URIs. so that they can discover more things.


[1] http://www.w3.org/DesignIssues/LinkedData.html