### PR TITLE
Remove normative part from example: SHOULD 2xx

### DIFF
--- a/http-warning/draft-cedik-http-warning-02.xml
+++ b/http-warning/draft-cedik-http-warning-02.xml
@@ -130,7 +130,7 @@ Content-Warning: "embedded-warning"; 1590190500
       </section>
       <section anchor="example" title="Example with HTTP Header Field and Embedded Warning">
          <t>
-            Since warnings do not have an effect on the returned HTTP status code, the response status code SHOULD be in the 2xx range, indicating that the intent of the client was successful.
+            Since warnings do not have an effect on the returned HTTP status code, the response status code will usually be in the 2xx range, indicating that the intent of the client was successful.
          </t>
 <figure><artwork><![CDATA[
 POST /example HTTP/1.1


### PR DESCRIPTION
## This PR

Removes a normative part from the examples.

This part contains a normative statement into an example. In RFC2119
[`SHOULD` is similar to `RECOMMENDED`](https://tools.ietf.org/html/rfc2119) while iiuc it's not a bad practice  to return warnings in a non-2xx response.