### PR TITLE
remove definition of a possible json format for returning warnings

### DIFF
--- a/http-warning/draft-cedik-http-warning-03.xml
+++ b/http-warning/draft-cedik-http-warning-03.xml
@@ -107,7 +107,7 @@ Content-Warning = sh-list
             To make it easier for clients to handle such an event, the Content-Warning type "embedded-warning" MAY be returned. In this case, the client MAY either treat the response according to its HTTP status code, or in addition the client MAY use the embedded warning information to understand the nature of the warning.
          </t>
          <t>
-            The "embedded-warning" type does not prescribe the way in which warnings are represented. The assumption is that the response will have embedded information that allows the client to learn about the nature of the warning. The following section describes a JSON structure that MAY be used to represent the warning. HTTP services are free to use this or other formats to represent the warning information they are embedding.
+            The "embedded-warning" type does not prescribe the way in which warnings are represented. The assumption is that the response will have embedded information that allows the client to learn about the nature of the warning.
          </t>
          <t>
             An exemplary Content-Warning field looks like this:
@@ -126,108 +126,6 @@ Content-Warning: "embedded-warning"; 1590190500
                The HTTP request method HEAD is an exception since it is allowed to return headers that are meant for being returned when sending a GET request. Therefore it MAY return the embedded-warning Content-Warning Type, although the body will be empty.
             </t>
          </section>
-      </section>
-      <section anchor="warning-format" title="JSON Warning Format">
-         <t>
-            The JSON warning format uses the JSON format described in
-            <xref target="RFC8259" />. It is intended to be used as a building block in the response schemas of JSON-based APIs.
-         </t>
-         <t>
-            In many current designs of JSON-based HTTP APIs, services represent response data as members of the returned JSON object. In order to make it easier for consumers to identify information about warnings, a top-level member is defined that contains all warning information in a representation. A "warnings" member MUST encapsulate the warnings that will be returned to the client.
-         </t>
-         <t>
-            When a condition occurs that can not be defined as a "hard error" (i.e., that allows clients to continue treating the resulting response as a success), additional information about this condition SHOULD be returned to the client. The "warnings" member MUST be an array that is structured with one object for each and every warning message that is returned to the client.
-         </t>
-         <t>
-            Entries in these individual objects follow the pattern described in <xref target="RFC7807" />.
-         </t>
-         <t>
-            When warnings are present the Content-Warning field (as defined in <xref target="content-warning-field" />)
-            SHOULD be set to indicate that warnings have be returned. This way a client will not
-            have to parse the response body to find out whether a warnings member is present.
-         </t>
-      </section>
-      <section anchor="example" title="Example with HTTP Field and Embedded Warning">
-         <t>
-            Since warnings do not have an effect on the returned HTTP status code, the response status code SHOULD be in the 2xx range, indicating that the intent of the client was successful.
-         </t>
-<figure><artwork><![CDATA[
-POST /example HTTP/1.1
-Host: example.com
-Accept: application/json
-
-HTTP/1.1 200 OK
-Content-Type: application/json
-Content-Warning: "embedded-warning"; 1590190500
-
-{
-  "request_id": "2326b087-d64e-43bd-a557-42171155084f",
-  "warnings": [
-    {
-      "detail": "Street name was too long. It has been shortened...",
-      "instance": "https://example.com/shipments/3a186c51/msgs/c94d",
-      "status": "200",
-      "title": "Street name too long. It has been shortened.",
-      "type": "https://example.com/errors/shortened_entry"
-    },
-    {
-      "detail": "City for this zipcode unknown. Code for shipment..",
-      "instance": "https://example.com/shipments/3a186c51/msgs/5927",
-      "status": "200",
-      "title": "City for zipcode unknown.",
-      "type": "https://example.com/errors/city_unknown"
-    }
-  ],
-  "id": "3a186c51d4281acb",
-  "carrier_tracking_no": "84168117830018",
-  "tracking_url": "http://example.com/3a186c51d",
-  "label_url": "http://example.com/shipping_label_3a186c51d.pdf",
-  "price": 3.4
-}
-]]></artwork></figure>
-         <t>
-            This example shows that the original intent was successful. If the original request was in fact not successful, a different status code SHOULD be returned. Embedded warnings are not tied to a specific http status code. Therefore they can be combined with every status code.
-         </t>
-
-<!--
-         <section anchor="hard.errors.with.warnings" title="Hard Errors with Warnings">
-            <t>
-               As described previously, errors are exceptions like occurrences where processing of the request stopped and the API consumer has to be informed of this "hard error" right away.
-            </t>
-            <t>
-               To indicate this fact the content-type MAY be set to application/problem+json and detailed information about the error will be returned in the body following the pattern described in <xref target="RFC7807" />.
-            </t>
-            <t>
-               If warnings occurred during the processing of the request, but before the processing
-               stopped, they SHOULD be returned alongside the errors.
-            </t>
-<figure><artwork><![CDATA[
-POST /example HTTP/1.1
-Host: example.com
-Accept: application/json
-
-HTTP/1.1 400 BAD REQUEST
-Content-Type: application/problem+json
-Content-Warning: "embedded-warning"; 1590190500
-
-{
-  "request_id": "2326b087-d64e-43bd-a557-42171155084f",
-  "detail": "The format of pickup time earliest was wrong.",
-  "status": "500",
-  "title": "Wrong format for pickup time",
-  "type": "https://example.com/errors/wrong_format"
-  "warnings": [
-    {
-      "detail": "Street name too long. It has been shortened to fit",
-      "status": "200",
-      "title": "Street name too long. It has been shortened.",
-      "type": "https://example.com/errors/shortened_entry"
-    }
-  ]
-}
-]]></artwork></figure>
-         </section>
--->
       </section>
       <section anchor="cache.considerations" title="Cache Considerations">
          <t>
@@ -250,7 +148,7 @@ Content-Warning: "embedded-warning"; 1590190500
             API providers need to exercise care when reporting warnings. Malicious actors could use this information for orchestrating attacks. Social engineering can also be a factor when warning information is returned by the API.
          </t>
          <t>
-            Clients processing warning information SHOULD make sure the right type of content was transmitted by checking the content-type header as well as the content-warning field. Content in the bodys warnings object SHOULD be processed accordingly. If no content-warning field was provided, clients are advised to ignore the content provided in the bodys warnings object.
+            Clients processing warning information SHOULD make sure the right type of content was transmitted by checking the content-type header as well as the content-warning field.
          </t>
          <section anchor="absence-of-a-response-body" title="Absence of a Response Body">
             <t>
@@ -261,14 +159,6 @@ Content-Warning: "embedded-warning"; 1590190500
             </t>
             <t>
                If an intermediary discovers a missing response body it MAY adjust the response to return a http status code of 500 - internal server error (see Section 6.6.1 of <xref target="RFC7231" />).
-            </t>
-         </section>
-         <section anchor="absence-of-warnings-in-the-response-body" title="Absence of Warnings in the Response Body">
-            <t>
-               When the response body does not contain warnings a client MAY use appropriate ways to inform the API provider about the fact. An error message MAY be ...
-            </t>
-            <t>
-               If an intermediary discovers missing warnings in the response body it MAY adjust the response to return warnings containing this information.
             </t>
          </section>
       </section>
@@ -343,7 +233,6 @@ Content-Warning: "embedded-warning"; 1590190500
             <seriesInfo name="RFC" value="2119"/>
             <seriesInfo name="DOI" value="10.17487/RFC2119"/>
          </reference>
-
          <reference anchor="RFC3864" target="https://www.rfc-editor.org/info/rfc3864">
             <front>
                <title>Registration Procedures for Message Header Fields</title>


### PR DESCRIPTION
Feedback about the draft made it clear that providing a JSON response suggestion for warnings has been too much detail for adopting the I-D. Therefore we are removing it. 

There is an ongoing discussion about [including warnings into RFC7807bis](https://github.com/ietf-wg-httpapi/rfc7807bis/issues/12), which will probably the future example content when using JSON.

Also returning multiple problems is [being discussed over there](https://github.com/ietf-wg-httpapi/rfc7807bis/issues/6).